### PR TITLE
Fix contributor profile link from the History tab

### DIFF
--- a/pontoon/base/static/js/translate.js
+++ b/pontoon/base/static/js/translate.js
@@ -152,7 +152,7 @@ var Pontoon = (function (my) {
                     '">' +
                     '<div class="info">' +
                       ((!this.email) ? this.user :
-                        '<a href="users/' + this.email + '">' + this.user + '</a>') +
+                        '<a href="contributor/' + this.email + '">' + this.user + '</a>') +
                       '<time class="stress" datetime="' + this.date_iso + '">' + this.date + '</time>' +
                     '</div>' +
                     '<menu class="toolbar">' +


### PR DESCRIPTION
The link to a contributor profile in the History tab links to a non-existing users/ page. 
It should probably go to the contributor's profile instead.
